### PR TITLE
updated dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "phergie/phergie-irc-bot-react": "dev-master"
+        "phergie/phergie-irc-bot-react": "~1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.*",


### PR DESCRIPTION
Seeing a dependency conflict since @elazar updated other plugins to use the new 1.0 bot tag  (ie https://github.com/phergie/phergie-irc-plugin-react-pong/commit/cf526fbf615a3ceb16d73c6cd57912078b3cde29)

Tested with update and all seems to be working again
